### PR TITLE
Serve frontend via Express for local use

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,19 +28,13 @@ Evento is an experimental ticketing and crowdfunding platform built on the **Sol
    npm install
    ```
 
-3. **Start the API server**
+3. **Start the server**
    ```bash
    npm start
    ```
-   The API is now available at `http://localhost:3000`.
+   This serves both the API and the `Evento.html` interface at `http://localhost:3000`.
 
-4. **Launch the web interface**
-   ```bash
-   npx http-server -c-1 .
-   ```
-   Then open `http://localhost:8080/Evento.html` in your browser. The frontend is preconfigured to reach the API at `http://localhost:3000`.
-
-5. **Test ticket purchases**
+4. **Test ticket purchases**
    - Connect your Phantom wallet to the `devnet`.
    - Create an event or use the default ones.
    - Select a ticket and follow the on-screen instructions to sign the transaction.

--- a/server.js
+++ b/server.js
@@ -1,10 +1,12 @@
 const express = require('express');
 const cors = require('cors');
+const path = require('path');
 const { Connection, clusterApiUrl } = require('@solana/web3.js');
 
 const app = express();
 app.use(cors());
 app.use(express.json());
+app.use(express.static(__dirname));
 
 // Store simple in-memory sessions
 const sessions = new Map();
@@ -173,4 +175,8 @@ app.delete('/events/:id', (req, res) => {
 });
 
 const PORT = process.env.PORT || 3000;
+app.get('/', (_req, res) => {
+  res.sendFile(path.join(__dirname, 'Evento.html'));
+});
+
 app.listen(PORT, () => console.log(`Server listening on ${PORT}`));


### PR DESCRIPTION
## Summary
- serve `Evento.html` directly from Express so the app works with a single `npm start`
- document simplified local setup in the README

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_6899ca0e3274832cb1d0781b44d14d47