### PR TITLE
Fix ticket purchase event lookup

### DIFF
--- a/Evento.html
+++ b/Evento.html
@@ -3580,7 +3580,7 @@
                             
                             <div class="project-actions">
                                 ${isEvent ? `
-                                    <button class="btn btn-primary" type="button" onclick="showTickets('${event.id}')">
+                                    <button class="btn btn-primary" type="button" onclick="showTickets(${event.id})">
                                         Acheter tickets
                                     </button>
                                 ` : `
@@ -4044,7 +4044,8 @@
 
                 return;
             }
-            const event = events.find(e => e.id === eventId);
+            const id = parseInt(eventId, 10);
+            const event = events.find(e => e.id === id);
             if (!event || !event.tickets) return;
 
             // Créer le modal s'il n'existe pas


### PR DESCRIPTION
## Summary
- ensure ticket modal locates events using numeric IDs
- pass event IDs as numbers when opening the ticket modal

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6899d55040e0832c8c3c4ec4e3c69685