### PR TITLE
Replace browser popups with site-styled modals

### DIFF
--- a/Evento.html
+++ b/Evento.html
@@ -2796,7 +2796,8 @@
         }
 
         /* === MODAL TICKETS === */
-        .ticket-modal {
+        .ticket-modal,
+        .popup-modal {
             position: fixed;
             inset: 0;
             background: rgba(0, 0, 0, 0.8);
@@ -2807,7 +2808,8 @@
             backdrop-filter: blur(4px);
         }
 
-        .ticket-modal.show {
+        .ticket-modal.show,
+        .popup-modal.show {
             display: flex;
         }
 
@@ -2947,6 +2949,10 @@
         .modal-actions {
             text-align: center;
             margin-top: 24px;
+        }
+
+        .modal-input {
+            margin: 20px 0;
         }
 
         /* === FEATURE CARD NEW DESIGN === */
@@ -3377,7 +3383,7 @@
         function showMessage(containerId, type, text, duration = 5000) {
             const container = document.getElementById(containerId);
             const icons = { success: '✅', error: '❌', warning: '⚠️' };
-            
+
             container.innerHTML = `<div class="message ${type}">${icons[type]} ${text}</div>`;
             
             if (duration > 0) {
@@ -3385,6 +3391,99 @@
                     container.innerHTML = '';
                 }, duration);
             }
+        }
+
+        async function showModal({ title, message, showCancel = false, input = false, defaultValue = '' }) {
+            return new Promise(resolve => {
+                let modal = document.getElementById('popupModal');
+                if (!modal) {
+                    modal = document.createElement('div');
+                    modal.id = 'popupModal';
+                    modal.className = 'popup-modal';
+                    modal.innerHTML = `
+                        <div class="modal-content">
+                            <div class="modal-header">
+                                <div class="modal-title" id="popupTitle"></div>
+                                <button class="modal-close" id="popupClose">&times;</button>
+                            </div>
+                            <div class="modal-body" id="popupMessage"></div>
+                            <div class="modal-input" id="popupInputContainer" style="display:none;">
+                                <input type="text" id="popupInput" class="form-input" />
+                            </div>
+                            <div class="modal-actions" id="popupActions"></div>
+                        </div>`;
+                    document.body.appendChild(modal);
+                }
+
+                const titleEl = document.getElementById('popupTitle');
+                const messageEl = document.getElementById('popupMessage');
+                const inputContainer = document.getElementById('popupInputContainer');
+                const inputEl = document.getElementById('popupInput');
+                const actionsEl = document.getElementById('popupActions');
+                const closeBtn = document.getElementById('popupClose');
+
+                titleEl.textContent = title || '';
+                messageEl.innerHTML = message.replace(/\n/g, '<br>');
+
+                if (input) {
+                    inputContainer.style.display = 'block';
+                    inputEl.value = defaultValue;
+                } else {
+                    inputContainer.style.display = 'none';
+                    inputEl.value = '';
+                }
+
+                actionsEl.innerHTML = '';
+
+                function close(result) {
+                    modal.classList.remove('show');
+                    document.removeEventListener('keydown', keyHandler);
+                    resolve(result);
+                }
+
+                const okBtn = document.createElement('button');
+                okBtn.textContent = showCancel ? 'OK' : 'Close';
+                okBtn.className = 'btn btn-primary';
+                okBtn.onclick = () => {
+                    const result = input ? inputEl.value.trim() : true;
+                    close(result);
+                };
+                actionsEl.appendChild(okBtn);
+
+                const cancelResult = input ? null : false;
+                if (showCancel) {
+                    const cancelBtn = document.createElement('button');
+                    cancelBtn.textContent = 'Cancel';
+                    cancelBtn.className = 'btn btn-secondary';
+                    cancelBtn.onclick = () => close(cancelResult);
+                    actionsEl.appendChild(cancelBtn);
+                    closeBtn.onclick = () => close(cancelResult);
+                    modal.onclick = e => { if (e.target === modal) close(cancelResult); };
+                } else {
+                    closeBtn.onclick = () => close(true);
+                    modal.onclick = e => { if (e.target === modal) close(true); };
+                }
+
+                const keyHandler = e => {
+                    if (e.key === 'Escape') close(showCancel ? cancelResult : true);
+                };
+                document.addEventListener('keydown', keyHandler);
+
+                modal.classList.add('show');
+                if (input) inputEl.focus();
+            });
+        }
+
+        function customAlert(message, title = 'Alert') {
+            return showModal({ title, message });
+        }
+
+        function customConfirm(message, title = 'Confirm') {
+            return showModal({ title, message, showCancel: true });
+        }
+
+        function customPrompt(message, title = 'Input', defaultValue = '') {
+            return showModal({ title, message, showCancel: true, input: true, defaultValue });
         }
 
         // === NAVIGATION ===
@@ -3411,7 +3510,7 @@
         // === WALLET MANAGEMENT ===
         async function toggleWallet() {
             if (walletAddress) {
-                if (confirm('Do you want to disconnect your wallet?')) {
+                if (await customConfirm('Do you want to disconnect your wallet?')) {
                     await disconnectWallet();
                 }
             } else {
@@ -3660,18 +3759,18 @@
             const event = events.find(e => e.id === eventId);
             if (!event) return;
 
-            const amountStr = prompt(`Fund "${event.title}"\nAmount in SOL (e.g., 10.5):`);
+            const amountStr = await customPrompt(`Fund "${event.title}"\nAmount in SOL (e.g., 10.5):`);
             if (!amountStr) return;
 
             const amount = parseSOL(amountStr);
             if (amount <= 0) {
-                alert('Invalid amount');
+                await customAlert('Invalid amount');
                 return;
             }
 
             try {
                 // Simulation de transaction Solana
-                const confirmed = confirm(
+                const confirmed = await customConfirm(
                     `Confirm transaction:\n\n` +
                     `Amount: ${formatSOL(amount)} SOL\n` +
                     `To: ${truncateAddress(event.beneficiaryWallet)}\n` +
@@ -3704,7 +3803,7 @@
             const event = events.find(e => e.id === eventId);
             if (!event) return;
 
-            if (!confirm(`Remove "${event.title}"?`)) return;
+            if (!await customConfirm(`Remove "${event.title}"?`)) return;
 
             try {
                 events = events.filter(e => e.id !== eventId);
@@ -4157,7 +4256,7 @@
             const total = ticket.price * window.selectedQuantity;
 
             try {
-                const confirmed = confirm(
+                const confirmed = await customConfirm(
                     `Confirm purchase:\n\n` +
                     `Event: ${event.title}\n` +
                     `Ticket: ${ticket.name}\n` +


### PR DESCRIPTION
## Summary
- Add reusable modal component with custom styling to replace native browser popups
- Implement helper functions (customAlert/Confirm/Prompt) using the new modal
- Update wallet toggle, funding, deletion and ticket purchase flows to use site-styled modals

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6899d873a798832cbaca39eac789cea1