### PR TITLE
feat: add orbital animation to overview cards

### DIFF
--- a/Evento.html
+++ b/Evento.html
@@ -2744,6 +2744,11 @@
 
         @keyframes spinBorder { to { transform: rotate(360deg); } }
 
+        @keyframes orbit {
+            from { transform: rotate(0deg) translateX(40px) rotate(0deg); }
+            to { transform: rotate(360deg) translateX(40px) rotate(-360deg); }
+        }
+
         .feature-card:hover {
             transform: translateY(-8px);
             box-shadow: 0 12px 32px rgba(0,0,0,0.6), 0 0 24px rgba(255,215,0,0.25);
@@ -2766,6 +2771,36 @@
             align-items: center;
             justify-content: center;
             transition: color .3s ease;
+            overflow: visible;
+        }
+
+        .feature-card .feature-icon::before {
+            content: "";
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            width: 80px;
+            height: 80px;
+            margin: -40px 0 0 -40px;
+            border: 1px dashed rgba(255,255,255,0.2);
+            border-radius: 50%;
+        }
+
+        .feature-card .feature-icon::after {
+            content: "";
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            width: 8px;
+            height: 8px;
+            margin: -4px 0 0 -4px;
+            border-radius: 50%;
+            background: var(--cosmic-gold);
+            animation: orbit 6s linear infinite;
+        }
+
+        .feature-card:hover .feature-icon::after {
+            background: var(--cosmic-platinum);
         }
 
         .feature-card:hover .feature-icon {


### PR DESCRIPTION
## Summary
- animate Overview feature icons with orbiting marker and ring

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6899e2e33bfc832ca2ae5827a12eb8e8