### PR TITLE
Fix ticket purchase button

### DIFF
--- a/Evento.html
+++ b/Evento.html
@@ -3565,7 +3565,7 @@
 
                             <div class="project-actions">
                                 ${isEvent ? `
-                                    <button class="btn btn-primary" type="button" onclick="showTickets(${event.id})">
+                                    <button class="btn btn-primary" type="button" onclick="showTickets('${event.id}')">
                                         Acheter tickets
                                     </button>
                                 ` : `
@@ -4033,8 +4033,7 @@
 
                 return;
             }
-            const id = parseInt(eventId, 10);
-            const event = events.find(e => e.id === id);
+            const event = events.find(e => e.id === eventId);
             if (!event || !event.tickets) return;
 
             // Créer le modal s'il n'existe pas


### PR DESCRIPTION
## Summary
- Pass event IDs as strings when opening ticket modal
- Match ticket lookup by string ID to display ticket options

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6899e864a9f0832c9ff954bda933ebbb