### PR TITLE
Add subtle promaa signature

### DIFF
--- a/Evento.html
+++ b/Evento.html
@@ -2844,6 +2844,18 @@
             font-size: 0.9rem;
             text-align: center;
         }
+        /* Subtle signature */
+        .signature {
+            position: fixed;
+            bottom: 12px;
+            right: 16px;
+            font-family: 'Georgia', serif;
+            font-style: italic;
+            font-size: 0.8rem;
+            color: var(--cosmic-silver);
+            opacity: 0.75;
+            pointer-events: none;
+        }
     </style>
 </head>
 <body>
@@ -4230,5 +4242,6 @@
 
         console.log('🚀 Evento Protocol - Ticketing version initialized');
     </script>
+    <div class="signature">— promaa</div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add a minimalist signature crediting **promaa** at the bottom of the site
- Include styling for a fixed, low-key signature element

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6899e8a67acc832c977e6e71e10c9345