### PR TITLE
Prepare static site for GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Evento is an experimental ticketing and crowdfunding platform built on the **Sol
    ```bash
    npm start
    ```
-   This serves both the API and the `Evento.html` interface at `http://localhost:3000`.
+   This serves both the API and the `docs/index.html` interface at `http://localhost:3000`.
 
 4. **Test ticket purchases**
    - Connect your Phantom wallet to the `devnet`.
@@ -65,19 +65,30 @@ An advanced version of the API is available in the `backend/` folder.
    The API also listens on `http://localhost:3000`.
 
 4. **Consume the API**
-   The `Evento.html` interface can be used as-is. Exposed routes include `GET /events`, `POST /events`, `POST /events/:id/tickets`…
+   The `docs/index.html` interface can be used as-is. Exposed routes include `GET /events`, `POST /events`, `POST /events/:id/tickets`…
 
 ## Project Structure
 
 ```
 .
-├── Evento.html          # Web interface
+├── docs/
+│   └── index.html       # Web interface served and published via GitHub Pages
 ├── server.js            # Minimal API (Express + in-memory storage)
 ├── package.json
 └── backend/             # Full API with MongoDB
     ├── models/          # Mongoose schemas
-    ├── routes/          # Express routes
-    └── server.js        # Entry point for the full API
+   ├── routes/          # Express routes
+   └── server.js        # Entry point for the full API
+
+## Deploying to GitHub Pages
+
+The static front-end lives in the `docs/` directory so it can be published directly.
+To deploy:
+
+1. Push your changes to the `main` branch.
+2. In your repository settings on GitHub, enable **GitHub Pages** and select the
+   `main` branch with the `/docs` folder as the source.
+3. Your site will be available at `https://<username>.github.io/<repository>/`.
 ```
 
 ## Development

--- a/docs/index.html
+++ b/docs/index.html
@@ -3168,7 +3168,8 @@
         // === CONFIGURATION ===
         const SOLANA_NETWORK = 'https://api.devnet.solana.com';
 
-        const API_BASE = 'http://localhost:3000';
+        const API_BASE =
+            window.location.hostname === 'localhost' ? 'http://localhost:3000' : '.';
        
         // === ÉTAT GLOBAL ===
         let walletAddress = null;
@@ -3488,11 +3489,13 @@
         async function loadEvents() {
             try {
                 const res = await fetch(`${API_BASE}/events`);
+                if (!res.ok) throw new Error('Failed to fetch events');
                 events = await res.json();
-                displayEvents();
             } catch (error) {
                 console.error('Error loading events:', error);
+                events = defaultEvents;
             }
+            displayEvents();
         }
 
         function saveEvents() {

--- a/server.js
+++ b/server.js
@@ -6,7 +6,7 @@ const { Connection, clusterApiUrl } = require('@solana/web3.js');
 const app = express();
 app.use(cors());
 app.use(express.json());
-app.use(express.static(__dirname));
+app.use(express.static(path.join(__dirname, 'docs')));
 
 // Store simple in-memory sessions
 const sessions = new Map();
@@ -176,7 +176,7 @@ app.delete('/events/:id', (req, res) => {
 
 const PORT = process.env.PORT || 3000;
 app.get('/', (_req, res) => {
-  res.sendFile(path.join(__dirname, 'Evento.html'));
+  res.sendFile(path.join(__dirname, 'docs', 'index.html'));
 });
 
 app.listen(PORT, () => console.log(`Server listening on ${PORT}`));


### PR DESCRIPTION
## Summary
- Serve frontend from new `docs` directory for easier GitHub Pages hosting
- Add environment-aware API base and fallback event loading
- Document GitHub Pages deployment steps in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6899ea1b30cc832c80399ffb04b21041