### PR TITLE
feat: prompt wallet connection before ticket purchase

### DIFF
--- a/Evento.html
+++ b/Evento.html
@@ -4147,7 +4147,11 @@
         }
 
         async function buyTicket() {
-            if (!walletAddress || window.selectedTicketIndex === null) return;
+            if (!walletAddress) {
+                showMessage('exploreMessages', 'error', 'Please connect your wallet first');
+                return;
+            }
+            if (window.selectedTicketIndex === null) return;
 
             const event = window.selectedEvent;
             const ticket = event.tickets[window.selectedTicketIndex];


### PR DESCRIPTION
## Summary
- ensure users are notified to connect their wallet before buying tickets

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6899ed20c208832cbde2016a7268997d