### PR TITLE
chore: prep for github pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Evento is an experimental ticketing and crowdfunding platform built on the **Sol
    ```bash
    npm start
    ```
-   This serves both the API and the `Evento.html` interface at `http://localhost:3000`.
+   This serves both the API and the `index.html` interface at `http://localhost:3000`.
 
 4. **Test ticket purchases**
    - Connect your Phantom wallet to the `devnet`.
@@ -65,13 +65,13 @@ An advanced version of the API is available in the `backend/` folder.
    The API also listens on `http://localhost:3000`.
 
 4. **Consume the API**
-   The `Evento.html` interface can be used as-is. Exposed routes include `GET /events`, `POST /events`, `POST /events/:id/tickets`…
+   The `index.html` interface can be used as-is. Exposed routes include `GET /events`, `POST /events`, `POST /events/:id/tickets`…
 
 ## Project Structure
 
 ```
 .
-├── Evento.html          # Web interface
+├── index.html          # Web interface
 ├── server.js            # Minimal API (Express + in-memory storage)
 ├── package.json
 └── backend/             # Full API with MongoDB
@@ -79,6 +79,12 @@ An advanced version of the API is available in the `backend/` folder.
     ├── routes/          # Express routes
     └── server.js        # Entry point for the full API
 ```
+
+## Deploying to GitHub Pages
+
+1. Ensure `index.html` is committed in the repository root or a `docs/` folder.
+2. Push the repository to GitHub and enable **GitHub Pages** in the repository settings.
+3. The page assumes the API is served from the same origin. If your API is hosted elsewhere, set `window.API_BASE` before loading the script.
 
 ## Development
 

--- a/index.html
+++ b/index.html
@@ -3168,7 +3168,7 @@
         // === CONFIGURATION ===
         const SOLANA_NETWORK = 'https://api.devnet.solana.com';
 
-        const API_BASE = 'http://localhost:3000';
+        const API_BASE = window.API_BASE || '';
        
         // === GLOBAL STATE ===
         let walletAddress = null;

--- a/server.js
+++ b/server.js
@@ -176,7 +176,7 @@ app.delete('/events/:id', (req, res) => {
 
 const PORT = process.env.PORT || 3000;
 app.get('/', (_req, res) => {
-  res.sendFile(path.join(__dirname, 'Evento.html'));
+  res.sendFile(path.join(__dirname, 'index.html'));
 });
 
 app.listen(PORT, () => console.log(`Server listening on ${PORT}`));


### PR DESCRIPTION
## Summary
- rename Evento.html to index.html and allow overriding API base for static hosting
- update server to send index.html
- document GitHub Pages deployment steps

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6899f18919f0832cb032499809683fb0