### PR TITLE
docs: pave the way for GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,41 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Prepare site
+        run: |
+          mkdir -p dist/docs
+          cp index.html dist/
+          cp backend/README.md dist/backend.md
+          cp docs/*.md dist/docs/
+          cp docs/_config.yml dist/_config.yml
+      - uses: actions/configure-pages@v3
+      - uses: actions/upload-pages-artifact@v2
+        with:
+          path: dist
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v2

--- a/README.md
+++ b/README.md
@@ -1,97 +1,61 @@
 # Evento
 
-Evento is an experimental ticketing and crowdfunding platform built on the **Solana** blockchain. It provides a single-page web interface (HTML/JavaScript) to create events, sell tickets and verify on-chain payments. The API is built with **Node.js** and **Express**; a more complete MongoDB-backed implementation lives in the `backend` directory.
+Evento is an experimental ticketing and crowdfunding platform built on the **Solana** blockchain. It ships with a minimal in-memory API and an optional MongoDB-backed backend.
 
-## Key Features
+## Table of Contents
+- [Project Overview](#project-overview)
+- [Quick Start](#quick-start)
+- [Full API with MongoDB](#full-api-with-mongodb)
+- [Project Structure](#project-structure)
+- [Additional Documentation](#additional-documentation)
+- [GitHub Pages](#github-pages)
+- [License](#license)
 
-- Phantom wallet connection and verification on the Solana *devnet*.
-- Create events and manage a ticket list.
-- Purchase tickets with SOL transfers and update the collected amount.
-- Simple REST API (`server.js`) or full database-backed API (`backend/`).
-
-## Requirements
-
-- [Node.js](https://nodejs.org/) (version 18 or newer recommended)
-- [npm](https://www.npmjs.com/) (ships with Node.js)
-- Optional: [MongoDB](https://www.mongodb.com/) if using the full version in `backend/`
+## Project Overview
+- Connect a [Phantom](https://phantom.app/) wallet on the Solana **devnet**.
+- Create events with ticket tiers and monitor funds raised.
+- Purchase tickets by signing SOL transfers; transactions are verified on-chain.
+- Start with the simple in-memory API in `server.js` or switch to the MongoDB implementation in `backend/`.
 
 ## Quick Start
-
-1. **Clone the repository**
-   ```bash
-   git clone <REPO_URL>
-   cd Evento
-   ```
-
-2. **Install dependencies for the minimal API**
+1. **Install dependencies**
    ```bash
    npm install
    ```
-
-3. **Start the server**
+2. **Run the minimal API and web app**
    ```bash
    npm start
    ```
-   This serves both the API and the `index.html` interface at `http://localhost:3000`.
+   The server exposes the REST API and serves `index.html` at [http://localhost:3000](http://localhost:3000).
+3. **Use the interface**
+   - Connect a Phantom wallet configured for devnet.
+   - Create an event or use one of the seeded examples.
+   - Select a ticket and follow the prompts to sign the transaction.
 
-4. **Test ticket purchases**
-   - Connect your Phantom wallet to the `devnet`.
-   - Create an event or use the default ones.
-   - Select a ticket and follow the on-screen instructions to sign the transaction.
-
-## Using the full API with MongoDB
-
-An advanced version of the API is available in the `backend/` folder.
-
-1. **Installation**
-   ```bash
-   cd backend
-   npm install
-   ```
-
-2. **Environment variables**
-   Create a `.env` file at the root of `backend/` containing, for example:
-   ```env
-   MONGO_URI=mongodb://127.0.0.1:27017/evento
-   SOLANA_SECRET_KEY=[0,1,2,...]
-   ```
-   - `MONGO_URI`: MongoDB connection URI.
-   - `SOLANA_SECRET_KEY`: server wallet secret key (64-element JSON array).
-
-3. **Start the full API**
-   ```bash
-   npm start
-   ```
-   The API also listens on `http://localhost:3000`.
-
-4. **Consume the API**
-   The `index.html` interface can be used as-is. Exposed routes include `GET /events`, `POST /events`, `POST /events/:id/tickets`…
+## Full API with MongoDB
+A richer API that persists events and contributions lives under [`backend/`](backend/). A separate `README` in that directory covers setup in detail, including required environment variables such as `MONGO_URI` and `SOLANA_SECRET_KEY`.
 
 ## Project Structure
-
 ```
 .
 ├── index.html          # Web interface
-├── server.js            # Minimal API (Express + in-memory storage)
+├── server.js          # Minimal API (Express + in-memory storage)
 ├── package.json
-└── backend/             # Full API with MongoDB
-    ├── models/          # Mongoose schemas
-    ├── routes/          # Express routes
-    └── server.js        # Entry point for the full API
+├── backend/           # Full API with MongoDB
+└── docs/              # Additional documentation
 ```
 
-## Deploying to GitHub Pages
+## Additional Documentation
+- [Architecture overview](docs/architecture.md)
 
-1. Ensure `index.html` is committed in the repository root or a `docs/` folder.
-2. Push the repository to GitHub and enable **GitHub Pages** in the repository settings.
-3. The page assumes the API is served from the same origin. If your API is hosted elsewhere, set `window.API_BASE` before loading the script.
+## GitHub Pages
+The repository includes a workflow at `.github/workflows/pages.yml` that builds a static site containing `index.html` and the
+contents of `docs/`. To publish:
 
-## Development
+1. Enable GitHub Pages in the repository settings and choose **GitHub Actions** as the source.
+2. Push to `main` and the site will automatically deploy to the configured Pages URL.
 
-- The Express API uses `cors` and `express.json`.
-- Solana transactions are verified via `@solana/web3.js` on the `devnet` network.
-- The MongoDB version persists events, tickets and contributions.
+The generated site serves the dApp on the root path and documentation under `/docs`.
 
 ## License
-
-Project distributed under the ISC license.
+Distributed under the ISC license.

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,28 @@
+# Backend API
+
+This folder contains a MongoDB-backed version of the Evento API. It uses Express and Mongoose to persist events, tickets and contributions.
+
+## Setup
+1. **Install dependencies**
+   ```bash
+   npm install
+   ```
+2. **Configure environment variables**
+   Create a `.env` file in this directory:
+   ```env
+   MONGO_URI=mongodb://127.0.0.1:27017/evento
+   SOLANA_SECRET_KEY=[0,1,2,...]  # JSON array of 64 numbers
+   ```
+3. **Start the server**
+   ```bash
+   npm start
+   ```
+
+The API listens on `http://localhost:3000` by default and exposes routes under `/events`.
+
+## Available Endpoints
+- `GET /events` — list events.
+- `POST /events` — create an event.
+- `POST /events/:id/tickets` — purchase a ticket and optionally partially sign a transaction.
+
+Data shapes mirror those used by the minimal `server.js` implementation.

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,2 @@
+title: Evento Docs
+theme: minima

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,18 @@
+# Architecture Overview
+
+Evento consists of a small front-end, a REST API and optional database persistence. The default setup stores data in memory, while the `backend/` directory provides a MongoDB-backed implementation.
+
+## Components
+- **Browser** — `index.html` uses JavaScript to call the API and interact with a Phantom wallet.
+- **API** — `server.js` exposes endpoints to create events, buy tickets and verify Solana transactions.
+- **Blockchain** — SOL transfers are verified against the Solana devnet via `@solana/web3.js`.
+- **Database (optional)** — the `backend/` API persists events and ticket sales in MongoDB.
+
+## Data Flow
+```
+Browser ----HTTP----> Express API ----> Solana devnet
+                       |
+                       └----> MongoDB (backend version)
+```
+
+The web page and API are served from the same origin during development. Deployments can host them separately by adjusting the `API_BASE` variable before loading the script.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,9 @@
+# Evento Documentation
+
+Welcome to the docs site for Evento. These pages provide guidance on how the protocol works and how to extend it.
+
+## Pages
+- [Architecture overview](architecture.md)
+- [Backend API setup](../backend.html)
+
+The main dApp interface lives at the site root (`index.html`) once GitHub Pages is enabled.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that publishes `index.html` and `docs` to GitHub Pages
- introduce `docs/index.md` and Jekyll config for Pages site
- document how to enable the Pages workflow in the top-level README

## Testing
- `npm test` *(fails: Error: no test specified)*
- `cd backend && npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6899f2d3a6b0832c96f03c4acf4e7f2f