### PR TITLE
Improve ticket purchase messaging for buyers

### DIFF
--- a/index.html
+++ b/index.html
@@ -4226,16 +4226,16 @@
                 });
                 if (!res.ok) throw new Error('Server error');
 
-                showMessage('createMessages', 'success', `✅ ${window.selectedQuantity} ticket(s) purchased successfully!`);
+                showMessage('exploreMessages', 'success', `✅ Purchased ${window.selectedQuantity} ${ticket.name} ticket(s) for "${event.title}"`);
                 closeTicketModal();
                 loadEvents();
 
             } catch (error) {
                 console.error('Purchase error:', error);
                 if (error && (error.message?.includes('User rejected') || error.code === 4001)) {
-                    showMessage('createMessages', 'error', 'Signature declined');
+                    showMessage('exploreMessages', 'error', 'Signature declined');
                 } else {
-                    showMessage('createMessages', 'error', 'Error during purchase: ' + error.message);
+                    showMessage('exploreMessages', 'error', 'Error during purchase: ' + error.message);
                 }
                 const btn = document.getElementById('buyTicketBtn');
                 btn.innerHTML = 'Buy ticket';


### PR DESCRIPTION
## Summary
- display ticket purchase success and errors in Explore section
- clarify success message with event and ticket details

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_689a027d1940832cbab6f4f806ae1a8b