### PR TITLE
Fix Phantom wallet provider detection

### DIFF
--- a/index.html
+++ b/index.html
@@ -3384,10 +3384,17 @@
         }
 
         function getProvider() {
+            // Prefer the explicit Phantom provider if available
+            if (window.phantom && window.phantom.solana && window.phantom.solana.isPhantom) {
+                return window.phantom.solana;
+            }
+
+            // Fallback to the legacy global Solana provider
             if ('solana' in window) {
                 const provider = window.solana;
-                if (provider.isPhantom) return provider;
+                if (provider && provider.isPhantom) return provider;
             }
+
             return null;
         }
 


### PR DESCRIPTION
## Summary
- prefer `window.phantom.solana` when selecting the Phantom provider
- fall back to legacy `window.solana` check

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689a0593b038832cb2a9001011fb3f83