### PR TITLE
feat: prompt wallet connect on ticket purchase

### DIFF
--- a/index.html
+++ b/index.html
@@ -4062,9 +4062,7 @@
         // === TICKET MANAGEMENT ===
         function showTickets(eventId) {
             if (!walletAddress) {
-                showMessage('exploreMessages', 'error', 'Please connect your wallet');
-
-                return;
+                showMessage('exploreMessages', 'info', 'Connect your wallet to purchase tickets');
             }
             const id = parseInt(eventId, 10);
             const event = events.find(e => e.id === id);
@@ -4170,7 +4168,8 @@
         async function buyTicket() {
             if (!walletAddress) {
                 showMessage('exploreMessages', 'error', 'Please connect your wallet first');
-                return;
+                await connectWallet();
+                if (!walletAddress) return;
             }
             if (window.selectedTicketIndex === null) return;
 


### PR DESCRIPTION
## Summary
- allow viewing ticket options without a connected wallet
- prompt wallet connection before processing ticket purchases

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689a05755650832c9dbd81f0982cb5c0