### PR TITLE
style: align Explore section with Launch page design

### DIFF
--- a/index.html
+++ b/index.html
@@ -2230,20 +2230,20 @@
 
         /* === EXPLORE PAGE DESIGN === */
         .explore-header {
-            margin-bottom: 48px;
+            max-width: 1000px;
+            margin: 0 auto 48px;
+            padding: 0 20px;
         }
 
         .explore-hero {
-            background: linear-gradient(135deg, 
-                rgba(20, 20, 25, 0.95) 0%, 
-                rgba(35, 35, 40, 0.9) 100%
-            );
-            border: 1px solid rgba(255, 215, 0, 0.1);
-            border-radius: 24px;
+            background: rgba(42, 42, 42, 0.6);
+            border: 1px solid rgba(255, 215, 0, 0.2);
+            border-radius: 16px;
             padding: 48px 40px;
             margin-bottom: 32px;
             position: relative;
             overflow: hidden;
+            text-align: center;
         }
 
         .explore-hero::before {
@@ -2253,9 +2253,9 @@
             left: 0;
             right: 0;
             bottom: 0;
-            background: 
-                radial-gradient(circle at 20% 20%, rgba(255, 215, 0, 0.08) 0%, transparent 50%),
-                radial-gradient(circle at 80% 80%, rgba(0, 212, 255, 0.06) 0%, transparent 50%);
+            background:
+                radial-gradient(circle at 20% 20%, rgba(255, 215, 0, 0.1) 0%, transparent 50%),
+                radial-gradient(circle at 80% 80%, rgba(255, 179, 71, 0.08) 0%, transparent 50%);
             pointer-events: none;
         }
 
@@ -2265,57 +2265,58 @@
         }
 
         .explore-title {
-            font-size: 42px;
-            font-weight: 800;
-            color: #ffffff;
+            font-size: 2.5rem;
+            font-weight: 600;
+            color: var(--cosmic-platinum);
             margin-bottom: 16px;
-            font-family: 'SF Pro Display', -apple-system, sans-serif;
-            letter-spacing: -0.02em;
-            line-height: 1.1;
+            font-family: 'Inter', sans-serif;
         }
 
         .explore-subtitle {
-            font-size: 18px;
-            color: rgba(255, 255, 255, 0.7);
+            font-size: 1.1rem;
+            color: var(--cosmic-silver);
             margin-bottom: 40px;
-            font-family: 'SF Pro Text', -apple-system, sans-serif;
+            font-family: 'Inter', sans-serif;
             line-height: 1.5;
             max-width: 600px;
+            margin-left: auto;
+            margin-right: auto;
         }
 
         .explore-stats {
             display: flex;
-            gap: 48px;
+            justify-content: center;
+            gap: 40px;
             flex-wrap: wrap;
         }
 
         .stat-item {
-            text-align: left;
+            text-align: center;
         }
 
         .stat-number {
             font-size: 32px;
             font-weight: 700;
-            background: linear-gradient(135deg, #FFD700 0%, #FFA500 100%);
+            background: var(--gradient-cosmic);
             -webkit-background-clip: text;
             -webkit-text-fill-color: transparent;
             background-clip: text;
-            font-family: 'SF Pro Display', -apple-system, sans-serif;
+            font-family: 'Inter', sans-serif;
             line-height: 1;
             margin-bottom: 8px;
         }
 
         .stat-label {
             font-size: 14px;
-            color: rgba(255, 255, 255, 0.6);
-            font-family: 'SF Pro Text', -apple-system, sans-serif;
+            color: var(--cosmic-silver);
+            font-family: 'Inter', sans-serif;
             text-transform: uppercase;
             letter-spacing: 0.5px;
         }
 
         .explore-filters {
             display: flex;
-            justify-content: flex-end;
+            justify-content: center;
             align-items: center;
             gap: 24px;
             flex-wrap: wrap;
@@ -2329,23 +2330,23 @@
         .search-input {
             width: 100%;
             padding: 14px 48px 14px 20px;
-            background: rgba(25, 25, 30, 0.8);
-            border: 1px solid rgba(255, 255, 255, 0.1);
+            background: rgba(42, 42, 42, 0.6);
+            border: 1px solid rgba(255, 215, 0, 0.2);
             border-radius: 16px;
-            color: #ffffff;
+            color: var(--cosmic-platinum);
             font-size: 14px;
-            font-family: 'SF Pro Text', -apple-system, sans-serif;
+            font-family: 'Inter', sans-serif;
             transition: all 0.2s ease;
         }
 
         .search-input:focus {
             outline: none;
-            border-color: rgba(255, 215, 0, 0.4);
-            background: rgba(25, 25, 30, 0.95);
+            border-color: var(--cosmic-gold);
+            background: rgba(42, 42, 42, 0.9);
         }
 
         .search-input::placeholder {
-            color: rgba(255, 255, 255, 0.5);
+            color: var(--cosmic-silver);
         }
 
         .search-icon {
@@ -2353,7 +2354,7 @@
             right: 16px;
             top: 50%;
             transform: translateY(-50%);
-            color: rgba(255, 255, 255, 0.5);
+            color: var(--cosmic-silver);
             font-size: 16px;
             pointer-events: none;
         }


### PR DESCRIPTION
## Summary
- Restyle Explore hero and layout using Launch page's cosmic theme
- Use Launch typography and gradients for Explore titles and stats
- Center filters and apply cosmic-themed search input styling

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689a0c1d457c832ca2dd159ccd092463