### PR TITLE
feat: add configurable API base

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ Local Development API (Optional)
   - GET /events – list events
   - POST /events/:id/tickets – verify the provided transaction signature and update ticket sales
 
+Remote Backend
+- To point the app to a hosted API (Render, Railway, etc.), edit `config.js` at the project root.
+- Replace `<URL_API_DISTANTE>` with your backend URL, for example:
+  ```js
+  window.API_BASE = "https://your-backend.onrender.com";
+  ```
+
 Customizing Events
 - Edit default events in `index.html` (look for `defaultEvents`).
 - For the Node server list, edit the `events` array in `server.js`.

--- a/config.js
+++ b/config.js
@@ -1,0 +1,2 @@
+window.API_BASE = "https://<URL_API_DISTANTE>";
+

--- a/index.html
+++ b/index.html
@@ -3191,6 +3191,7 @@
         </section>
     </div>
 
+    <script src="config.js"></script>
     <!-- Solana Web3.js -->
     <script src="https://unpkg.com/@solana/web3.js@1.98.4/lib/index.iife.min.js"></script>
 


### PR DESCRIPTION
## Summary
- add config.js to configure API base URL
- load config.js before other scripts in index.html
- document remote backend configuration in README

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689a3c675f14832cadc248f0d4ca4e18