### PR TITLE
docs: add GitHub Pages deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,5 +115,22 @@ contents of `docs/`. To publish:
 
 The generated site serves the dApp on the root path and documentation under `/docs`.
 
+## Déploiement GitHub Pages
+
+1. **Activer GitHub Pages**
+   - Dans les paramètres du dépôt, section *Pages*, sélectionner **GitHub Actions** comme source.
+   - Chaque push sur `main` déclenche le workflow `.github/workflows/pages.yml` qui construit et publie le site statique.
+
+2. **Configurer l'URL de l'API**
+   - Créer un fichier `config.js` à la racine du projet contenant :
+     ```js
+     window.API_BASE = "https://votre-backend.example";
+     ```
+   - Référencer ce fichier dans `index.html` (par exemple avec `<script src="config.js"></script>`) avant le script principal afin que `API_BASE` soit disponible.
+
+3. **Héberger le backend**
+   - Déployer l'API (`server.js` ou `backend/`) sur un service compatible tel que Render ou Railway.
+   - Récupérer l'URL publique du service et la reporter dans `config.js` pour exposer le backend au frontend.
+
 ## License
 Distributed under the ISC license.


### PR DESCRIPTION
## Summary
- document how to enable the Pages workflow
- explain creation of `config.js` and `API_BASE`
- outline hosting the backend and exposing its URL

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689a3c6f7fe0832c9349488c7613fa65