### PR TITLE
docs: document optional config override

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -1,0 +1,5 @@
+/**
+ * Exemple de fichier de configuration pour Evento.
+ * Copiez-le en `config.js` et ajustez l'URL de l'API.
+ */
+window.API_BASE = 'https://exemple.com/api';

--- a/index.html
+++ b/index.html
@@ -3193,6 +3193,8 @@
 
     <!-- Solana Web3.js -->
     <script src="https://unpkg.com/@solana/web3.js@1.98.4/lib/index.iife.min.js"></script>
+    <!-- Charge config.js s'il est présent ; en son absence, l'API locale ('') sera utilisée -->
+    <script src="config.js"></script>
 
     <script>
         // === CONFIGURATION ===


### PR DESCRIPTION
## Summary
- document how missing `config.js` falls back to local API
- add `config.example.js` with `API_BASE` example

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689a3c71e908832ca762310e92d7d14a