### PR TITLE
chore: convert server to esm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
   "name": "evento",
   "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
+  "description": "Backend server for Evento platform",
+  "main": "server.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node server.js"
   },
   "keywords": [],
-  "author": "",
+  "author": "Evento Team",
   "license": "ISC",
-  "type": "commonjs",
+  "type": "module",
   "dependencies": {
     "@solana/web3.js": "^1.98.4",
     "cors": "^2.8.5",

--- a/server.js
+++ b/server.js
@@ -1,7 +1,11 @@
-const express = require('express');
-const cors = require('cors');
-const path = require('path');
-const { Connection, clusterApiUrl, LAMPORTS_PER_SOL } = require('@solana/web3.js');
+import express from 'express';
+import cors from 'cors';
+import path from 'path';
+import { Connection, clusterApiUrl, LAMPORTS_PER_SOL } from '@solana/web3.js';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 // Reusable Solana connection
 const connection = new Connection(
@@ -228,3 +232,5 @@ app.get('/', (_req, res) => {
 });
 
 app.listen(PORT, () => console.log(`Server listening on ${PORT}`));
+
+export default app;


### PR DESCRIPTION
## Summary
- switch package type to module and point main entry to server.js
- migrate server.js to ES module syntax

## Testing
- `node server.js`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689a42cfc388832c913977a41878db0c