### PR TITLE
Use French school names and update Point Gamma description

### DIFF
--- a/index.html
+++ b/index.html
@@ -3214,8 +3214,8 @@
         const defaultEvents = [
               {
                   id: '1',
-                  title: '42 School Hackathon',
-                  organization: '42 School',
+                  title: 'Ecole 42 Hackathon',
+                  organization: 'Ecole 42',
                   goal: 2000,
                   raised: 1500,
                   description: '48 hours of creativity and coding for students and enthusiasts.',
@@ -3230,8 +3230,8 @@
               },
               {
                   id: '2',
-                  title: 'Central Lyon Challenge',
-                  organization: 'Central Lyon',
+                  title: 'Centrale Lyon Challenge',
+                  organization: 'Centrale Lyon',
                   goal: 4000,
                   raised: 3000,
                   description: 'Inter-school sports tournament with various disciplines and a festive atmosphere.',
@@ -3247,11 +3247,11 @@
               },
               {
                   id: '3',
-                  title: 'Polytechnic Point Gamma',
-                  organization: 'Polytechnic School',
+                  title: 'Polytechnique Point Gamma',
+                  organization: 'Ecole Polytechnique',
                   goal: 6000,
                   raised: 4500,
-                  description: 'The largest student gala in Europe organized by the Polytechnic School.',
+                  description: 'The largest student festival in France organized by Ecole Polytechnique.',
 
                 imageUrl: 'https://images.unsplash.com/photo-1506157786151-b8491531f063?auto=format&fit=crop&w=1200&q=80',
 

--- a/server.js
+++ b/server.js
@@ -20,8 +20,8 @@ const sessions = new Map();
 const events = [
   {
     id: 1,
-    title: '42 School Hackathon',
-    organization: '42 School',
+    title: 'Ecole 42 Hackathon',
+    organization: 'Ecole 42',
     goal: 5000,
     raised: 1500,
     description:
@@ -64,7 +64,7 @@ const events = [
     goal: 10000,
     raised: 4500,
     description:
-      'The largest student gala in Europe organized by Ecole Polytechnique.',
+      'The largest student festival in France organized by Ecole Polytechnique.',
     imageUrl:
       'https://images.unsplash.com/photo-1506157786151-b8491531f063?auto=format&fit=crop&w=1200&q=80',
 


### PR DESCRIPTION
## Summary
- Display French names for Ecole 42, Centrale Lyon, and Ecole Polytechnique in default events.
- Describe Point Gamma as the largest student festival in France instead of a gala in Europe.

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689a42e7f1ec832c8ff26cd733d659c6