### PR TITLE
chore: refine pages deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -24,15 +24,16 @@ jobs:
           mkdir -p dist/docs
           cp index.html dist/
           cp config.js dist/
-          cp backend/README.md dist/backend.md
+          cp -r public dist/public
           cp docs/*.md dist/docs/
-          cp docs/_config.yml dist/_config.yml
       - name: Verify dist contents
         run: |
           ls -R dist
           test -f dist/index.html
           test -f dist/config.js
+          test -d dist/public
           test -d dist/docs
+          test -z "$(find dist -mindepth 1 -maxdepth 1 ! -name index.html ! -name config.js ! -name public ! -name docs)"
       - uses: actions/configure-pages@v3
       - uses: actions/upload-pages-artifact@v2
         with:


### PR DESCRIPTION
## Summary
- stop copying backend README and other removed artifacts
- include `public/` directory in Pages build
- verify only expected assets are deployed

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689a609c0fac832c9bb0ae61cfe1ee98