### PR TITLE
feat: prompt wallet unlock

### DIFF
--- a/index.html
+++ b/index.html
@@ -3457,6 +3457,25 @@
             return null;
         }
 
+        async function promptPhantomUnlock() {
+            provider = provider || getProvider();
+            if (!provider) return null;
+
+            try {
+                const res = await provider.connect({ onlyIfTrusted: false });
+                return res;
+            } catch (error) {
+                console.error('❌ Phantom unlock error:', error);
+                const msg =
+                    error && (error.message?.includes('User rejected') || error.code === 4001)
+                        ? 'Connection denied'
+                        : 'Connection failed';
+                showMessage('createMessages', 'error', msg);
+                showMessage('exploreMessages', 'error', msg);
+                return null;
+            }
+        }
+
         async function connectWallet() {
             provider = getProvider();
             if (!provider) {
@@ -3471,7 +3490,8 @@
             }
 
             try {
-                const response = await provider.connect();
+                const response = await promptPhantomUnlock();
+                if (!response) return;
                 walletAddress = response.publicKey.toString();
                 connection = new solanaWeb3.Connection(SOLANA_NETWORK, 'confirmed');
                 updateWalletUI();
@@ -3490,12 +3510,6 @@
                 }
             } catch (error) {
                 console.error('❌ Wallet connection error:', error);
-                const msg =
-                    error && (error.message?.includes('User rejected') || error.code === 4001)
-                        ? 'Connection denied'
-                        : 'Connection failed';
-                showMessage('createMessages', 'error', msg);
-                showMessage('exploreMessages', 'error', msg);
             }
         }
 
@@ -3521,13 +3535,10 @@
             provider = provider || getProvider();
             if (!provider || !provider.isPhantom) throw new Error('Please connect your Phantom wallet');
 
-            if (!provider.isConnected) {
-                const response = await provider.connect();
-                walletAddress = response.publicKey.toString();
-                updateWalletUI();
-            } else {
-                walletAddress = provider.publicKey.toString();
-            }
+            const response = await promptPhantomUnlock();
+            if (!response) throw new Error('Wallet connection required');
+            walletAddress = provider.publicKey.toString();
+            updateWalletUI();
 
             connection = connection || new solanaWeb3.Connection(SOLANA_NETWORK, 'confirmed');
 
@@ -3827,14 +3838,15 @@
             // Attempt to reconnect Phantom if already trusted
             provider = getProvider();
             if (provider) {
-                try {
-                    const resp = await provider.connect({ onlyIfTrusted: true });
-                    walletAddress = resp.publicKey.toString();
-                    connection = new solanaWeb3.Connection(SOLANA_NETWORK, 'confirmed');
-                    updateWalletUI();
-                } catch (err) {
-                    console.log('Auto-connect skipped', err);
-                }
+                // Auto-connect removed to avoid silent reconnection
+                // try {
+                //     const resp = await provider.connect({ onlyIfTrusted: true });
+                //     walletAddress = resp.publicKey.toString();
+                //     connection = new solanaWeb3.Connection(SOLANA_NETWORK, 'confirmed');
+                //     updateWalletUI();
+                // } catch (err) {
+                //     console.log('Auto-connect skipped', err);
+                // }
 
                 provider.on('accountChanged', (publicKey) => {
                     if (publicKey) {


### PR DESCRIPTION
## Summary
- prevent automatic Phantom reconnection on page load
- add `promptPhantomUnlock` helper to request extension unlock
- use helper in wallet connect and payment routines

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689a7343b5fc832c90da525953ee9bd1