### PR TITLE
Conditionally copy config.js in Pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           mkdir -p dist/docs
           cp index.html dist/
-          cp config.js dist/
+          if [ -f config.js ]; then cp config.js dist/; fi
           cp backend/README.md dist/backend.md
           cp docs/*.md dist/docs/
           cp docs/_config.yml dist/_config.yml


### PR DESCRIPTION
## Summary
- Avoid build failure when `config.js` is missing by copying it only if present during GitHub Pages build.

## Testing
- `npm test` *(fails: Error: no test specified)*


------
https://chatgpt.com/codex/tasks/task_e_689a761b2d98832c9896125e9079bbc7