### PR TITLE
Require wallet connection before ticket purchase

### DIFF
--- a/index.html
+++ b/index.html
@@ -4210,6 +4210,7 @@
         function showTickets(eventId) {
             if (!walletAddress) {
                 showMessage('exploreMessages', 'info', 'Connect your wallet to purchase tickets');
+                return;
             }
             const id = parseInt(eventId, 10);
             const event = events.find(e => e.id === id);


### PR DESCRIPTION
## Summary
- Require a connected wallet before displaying the ticket purchase modal

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689a7955464c832ca812f26dc6bbb626