### PR TITLE
feat: improve section typography responsiveness

### DIFF
--- a/index.html
+++ b/index.html
@@ -617,7 +617,7 @@
         }
 
         .section-title {
-            font-size: 48px;
+            font-size: clamp(2rem, 5vw, 3rem);
             font-weight: 700;
             line-height: 1;
             letter-spacing: -0.025em;
@@ -626,7 +626,7 @@
         }
 
         .section-subtitle {
-            font-size: 18px;
+            font-size: clamp(1rem, 2.5vw, 1.125rem);
             color: var(--muted-foreground);
             line-height: 1.6;
         }
@@ -1142,11 +1142,11 @@
             }
 
             .section-title {
-                font-size: 32px;
+                font-size: 2.5rem;
             }
 
             .section-subtitle {
-                font-size: 16px;
+                font-size: 1rem;
             }
 
             .section {
@@ -1160,6 +1160,16 @@
 
             .project-actions {
                 flex-direction: column;
+            }
+        }
+
+        @media (max-width: 480px) {
+            .section-title {
+                font-size: 2rem;
+            }
+
+            .section-subtitle {
+                font-size: 0.875rem;
             }
         }
 


### PR DESCRIPTION
## Summary
- replace fixed pixel sizes with clamp-based units for section titles and subtitles
- add media queries for <768px and <480px to refine font scaling

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run build:pages` (fails: cp docs/*.md: No such file or directory)


------
https://chatgpt.com/codex/tasks/task_e_689c73b5f594832cb630b873d63a6bbc